### PR TITLE
Fixed fatal errors that broke the mod

### DIFF
--- a/src/main/java/com/kuri0/rawinput/RawInput.java
+++ b/src/main/java/com/kuri0/rawinput/RawInput.java
@@ -49,15 +49,26 @@ public class RawInput
 						try {
 							Controller[] controllers;
 							controllers = createDefaultEnvironment().getControllers();
-								for (int i = 0; i < controllers.length; i++) {
-			        			if (controllers[i].getType() == Controller.Type.MOUSE) {
-			        				controllers[i].poll();
-			        				if (((Mouse)controllers[i]).getX().getPollData() != 0.0 || ((Mouse)controllers[i]).getY().getPollData() != 0.0) {
-			        					mouse = (Mouse)controllers[i];
-										Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("Found mouse"));
+							for (Controller controller : controllers) {
+								try {
+									if (controller.getType() == Controller.Type.MOUSE) {
+										controller.poll();
+										float px = ((Mouse) controller).getX().getPollData();
+										float py = ((Mouse) controller).getY().getPollData();
+										float eps = 0.1f;
+
+										// check if mouse is moving
+										if ((-eps < px && px < eps) || (-eps < py && py < eps)) {
+											mouse = (Mouse) controller;
+											Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText("Found mouse"));
+										}
 									}
-			        			}
-			        		}
+								}
+								catch (Exception e) {
+									// skip to next
+									e.printStackTrace();
+								}
+							}
 						} catch (ReflectiveOperationException e) {
 							// TODO Auto-generated catch block
 							e.printStackTrace();


### PR DESCRIPTION
There were two key errors in the original mod that made it not work.

1. When iterating through the list of controllers, if there was one exception in the entire process, the entire for loop would exit. This means that if in the list of controllers, a faulty controller is before the desired controller, the desired controller would never be reached.
2. The original code checked for float equality (namely, the mouse position to the double 0.0 exactly). Due to floating point errors, this is a very bad idea. The best solution is to compare a range of values (for example, -0.1 < x < 0.1).

I've fixed both these issues and can confirm the mod now works.